### PR TITLE
better-dragscroll: Add option to activate dragging when host initial state is toggled

### DIFF
--- a/keyboards/ploopyco/trackball_nano/keymaps/viam/keymap.c
+++ b/keyboards/ploopyco/trackball_nano/keymaps/viam/keymap.c
@@ -25,8 +25,16 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 void suspend_power_down_user(void) {
     // Switch off sensor + LED making trackball unable to wake host
     adns5050_power_down();
+
+    #if (defined(BETTER_DRAGSCROLL) && defined(BETTER_DRAGSCROLL_ON_HOST_VALUE_TOGGLED) && (defined(BETTER_DRAGSCROLL_SCRLK_ENABLE) || defined(BETTER_DRAGSCROLL_CAPLK_ENABLE) || defined(BETTER_DRAGSCROLL_NUMLK_ENABLE)) || (defined(VIA_ENABLE) && defined(PLOOPY_VIAMENUS)))
+        led_deinitialize_better_dragscroll();
+    #endif
 }
 
 void suspend_wakeup_init_user(void) {
     adns5050_init();
+
+    #if (defined(BETTER_DRAGSCROLL) && defined(BETTER_DRAGSCROLL_ON_HOST_VALUE_TOGGLED) && (defined(BETTER_DRAGSCROLL_SCRLK_ENABLE) || defined(BETTER_DRAGSCROLL_CAPLK_ENABLE) || defined(BETTER_DRAGSCROLL_NUMLK_ENABLE)) || (defined(VIA_ENABLE) && defined(PLOOPY_VIAMENUS)))
+        led_initialize_better_dragscroll();
+    #endif
 }

--- a/keyboards/ploopyco/trackball_nano/keymaps/viam/keymap.json
+++ b/keyboards/ploopyco/trackball_nano/keymaps/viam/keymap.json
@@ -7,6 +7,8 @@
     "keymap": "via",
     "layout": "LAYOUT",
     "modules": [
+        "plodah/mouse_jiggler",
+        "plodah/task_switch"
     ],
     "config": {
         "build": {

--- a/keyboards/ploopyco/trackball_nano/keymaps/viam/keymap.json
+++ b/keyboards/ploopyco/trackball_nano/keymaps/viam/keymap.json
@@ -7,8 +7,6 @@
     "keymap": "via",
     "layout": "LAYOUT",
     "modules": [
-        "plodah/mouse_jiggler",
-        "plodah/task_switch"
     ],
     "config": {
         "build": {
@@ -24,8 +22,8 @@
             "console": false,
             "deferred_exec": true,
             "encoder_map": false,
-            "extrakey": true,
-            "mousekey": true,
+            "extrakey": false,
+            "mousekey": false,
             "rgblight": false,
             "rgb_matrix": false,
             "tap_dance": false,

--- a/users/viam/0_keyboard_post_init_user.c
+++ b/users/viam/0_keyboard_post_init_user.c
@@ -1,0 +1,8 @@
+#if defined(BETTER_DRAGSCROLL)
+    #include "better_dragscroll.h"
+#endif // defined(BETTER_DRAGSCROLL)
+#if ( defined(BETTER_DRAGSCROLL) && ((defined(BETTER_DRAGSCROLL_SCRLK_ENABLE)) || defined(BETTER_DRAGSCROLL_CAPLK_ENABLE) || defined(BETTER_DRAGSCROLL_NUMLK_ENABLE) || (defined(VIA_ENABLE) && defined(PLOOPY_VIAMENUS))) || defined(COMMUNITY_MODULE_BETTER_DRAGSCROLL_ENABLED))
+    void keyboard_post_init_user(void) {
+      led_initialize_better_dragscroll();
+    }
+#endif //

--- a/users/viam/0_led_update_user.c
+++ b/users/viam/0_led_update_user.c
@@ -3,7 +3,7 @@
 #endif // defined(BETTER_DRAGSCROLL)
 #if ( defined(BETTER_DRAGSCROLL) && (defined(BETTER_DRAGSCROLL_SCRLK_ENABLE) || defined(BETTER_DRAGSCROLL_CAPLK_ENABLE) || defined(BETTER_DRAGSCROLL_NUMLK_ENABLE) || (defined(VIA_ENABLE) && defined(PLOOPY_VIAMENUS))) || defined(COMMUNITY_MODULE_BETTER_DRAGSCROLL_ENABLED))
     bool led_update_user(led_t led_state) {
-      if(led_update_better_dragscroll(led_state)){
+      if (led_update_better_dragscroll_led_state(led_state)){
         return true;
       }
       return false;

--- a/users/viam/better_dragscroll.h
+++ b/users/viam/better_dragscroll.h
@@ -18,5 +18,11 @@ bool better_dragscroll_enabled_bypress;
 void better_dragscroll_toggle(bool pressed);
 void better_dragscroll_momentary(bool pressed);
 #if defined(BETTER_DRAGSCROLL_SCRLK_ENABLE) || defined(BETTER_DRAGSCROLL_CAPLK_ENABLE) || defined(BETTER_DRAGSCROLL_NUMLK_ENABLE) || (defined(VIA_ENABLE) && defined(PLOOPY_VIAMENUS))
-    bool led_update_better_dragscroll(led_t led_state);
+    bool led_update_better_dragscroll_led_state(led_t led_state);
+
+    #if defined(BETTER_DRAGSCROLL_ON_HOST_VALUE_TOGGLED) || (defined(VIA_ENABLE) && defined(PLOOPY_VIAMENUS))
+        void led_initialize_better_dragscroll(void);
+        void led_deinitialize_better_dragscroll(void);
+        void led_update_better_dragscroll(void);
+    #endif
 #endif //     #if defined(BETTER_DRAGSCROLL_SCRLK_ENABLE) || defined(BETTER_DRAGSCROLL_CAPLK_ENABLE) || defined(BETTER_DRAGSCROLL_NUMLK_ENABLE) || (defined(VIA_ENABLE) && defined(PLOOPY_VIAMENUS))

--- a/users/viam/common.c
+++ b/users/viam/common.c
@@ -6,6 +6,7 @@
 #include "combos.c"
 #include "debug.c"
 #include "tapdance.c"
+#include "0_keyboard_post_init_user.c"
 #include "0_led_update_user.c"
 #include "0_pointing_device_task_user.c"
 #include "0_process_record_user.c"

--- a/users/viam/ploopy_via.c
+++ b/users/viam/ploopy_via.c
@@ -51,6 +51,12 @@
         #else // BETTER_DRAGSCROLL_END_ON_KEYPRESS
             .dragscroll_end_on_keypress = false,
         #endif // BETTER_DRAGSCROLL_END_ON_KEYPRESS
+
+        #if defined(BETTER_DRAGSCROLL_ON_HOST_VALUE_TOGGLED)
+            .dragscroll_on_host_value_toggled = true,
+        #else // BETTER_DRAGSCROLL_ON_HOST_VALUE_TOGGLED
+            .dragscroll_on_host_value_toggled = false,
+        #endif // BETTER_DRAGSCROLL_ON_HOST_VALUE_TOGGLED
     };
 
     void values_load(void)
@@ -221,6 +227,12 @@
                 dprintf("dragscroll_end_on_keypress: %d\n", ploopyvia_config.dragscroll_end_on_keypress);
                 break;
 
+            case id_ploopystuff_dragscroll_on_host_value_toggled:
+                ploopyvia_config.dragscroll_on_host_value_toggled = *value_data;
+                dprintf("dragscroll_on_host_value_toggled: %d\n", ploopyvia_config.dragscroll_on_host_value_toggled);
+                led_update_better_dragscroll();
+                break;
+
             case id_ploopystuff_dpi_presets:
                 dpi_array[value_data[0]] = (value_data[1]*10) * (ploopyvia_config.dpi_multiplier/20) ;
                 dprintf("dpi_presets[%d]: %d\n", value_data[0], value_data[1]);
@@ -299,6 +311,9 @@
             case id_ploopystuff_dragscroll_end_on_keypress:
                 *value_data = ploopyvia_config.dragscroll_end_on_keypress;
                 break;
+
+            case id_ploopystuff_dragscroll_on_host_value_toggled:
+                *value_data = ploopyvia_config.dragscroll_on_host_value_toggled;
         }
     }
 

--- a/users/viam/ploopy_via.h
+++ b/users/viam/ploopy_via.h
@@ -24,6 +24,7 @@ enum via_ploopystuff_value {
     id_ploopystuff_dragscroll_num,
     id_ploopystuff_dragscroll_scroll,
     id_ploopystuff_dragscroll_end_on_keypress,
+    id_ploopystuff_dragscroll_on_host_value_toggled,
     id_ploopystuff_dpi_presets = 31,
     id_ploopystuff_dpi_preset1 = 31,
     id_ploopystuff_dpi_preset2,
@@ -48,6 +49,7 @@ typedef struct {
     bool    dragscroll_num;
     bool    dragscroll_scroll;
     bool    dragscroll_end_on_keypress;
+    bool    dragscroll_on_host_value_toggled;
 } via_ploopystuff_config;
 
 via_ploopystuff_config ploopyvia_config;

--- a/via_json/mouse.via.json
+++ b/via_json/mouse.via.json
@@ -247,6 +247,11 @@
                             "label": "Dragscroll end on keypress",
                             "type": "toggle",
                             "content": ["id_ploopystuff_dragscroll_end_on_keypress", 0, 28]
+                        },
+                        {
+                            "label": "Dragscroll on Toggled Initial Host Values",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_on_host_value_toggled", 0, 29]
                         }
                     ]
                 },

--- a/via_json/trackball.via.json
+++ b/via_json/trackball.via.json
@@ -234,6 +234,11 @@
                             "label": "Dragscroll end on keypress",
                             "type": "toggle",
                             "content": ["id_ploopystuff_dragscroll_end_on_keypress", 0, 28]
+                        },
+                        {
+                            "label": "Dragscroll on Toggled Initial Host Values",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_on_host_value_toggled", 0, 29]
                         }
                     ]
                 },

--- a/via_json/trackball_madromys.via.json
+++ b/via_json/trackball_madromys.via.json
@@ -241,6 +241,11 @@
                             "label": "Dragscroll end on keypress",
                             "type": "toggle",
                             "content": ["id_ploopystuff_dragscroll_end_on_keypress", 0, 28]
+                        },
+                        {
+                            "label": "Dragscroll on Toggled Initial Host Values",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_on_host_value_toggled", 0, 29]
                         }
                     ]
                 },

--- a/via_json/trackball_mini.via.json
+++ b/via_json/trackball_mini.via.json
@@ -234,6 +234,11 @@
                             "label": "Dragscroll end on keypress",
                             "type": "toggle",
                             "content": ["id_ploopystuff_dragscroll_end_on_keypress", 0, 28]
+                        },
+                        {
+                            "label": "Dragscroll on Toggled Initial Host Values",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_on_host_value_toggled", 0, 29]
                         }
                     ]
                 },

--- a/via_json/trackball_nano.via.json
+++ b/via_json/trackball_nano.via.json
@@ -200,11 +200,6 @@
                             "label": "Dragscroll on Scroll Lock",
                             "type": "toggle",
                             "content": ["id_ploopystuff_dragscroll_scroll", 0, 27]
-                        },
-                        {
-                            "label": "Dragscroll end on keypress",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_dragscroll_end_on_keypress", 0, 28]
                         }
                     ]
                 },

--- a/via_json/trackball_nano.via.json
+++ b/via_json/trackball_nano.via.json
@@ -200,6 +200,11 @@
                             "label": "Dragscroll on Scroll Lock",
                             "type": "toggle",
                             "content": ["id_ploopystuff_dragscroll_scroll", 0, 27]
+                        },
+                        {
+                            "label": "Dragscroll on Toggled Initial Host Values",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_on_host_value_toggled", 0, 29]
                         }
                     ]
                 },

--- a/via_json/trackball_thumb.via.json
+++ b/via_json/trackball_thumb.via.json
@@ -239,6 +239,11 @@
                             "label": "Dragscroll end on keypress",
                             "type": "toggle",
                             "content": ["id_ploopystuff_dragscroll_end_on_keypress", 0, 28]
+                        },
+                        {
+                            "label": "Dragscroll on Toggled Initial Host Values",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_on_host_value_toggled", 0, 29]
                         }
                     ]
                 },


### PR DESCRIPTION
I tend to keep Num Lock always enabled while my keyboard is toggling
the value when I'm switching the scrolling key for my nano.

So instead of enabling the dragging phase depending on a fixed state of
a led, only care whether the led value had changed.

This also helps the case on hot-plug when a lock value is already set.