### PR TITLE
Include turbo_fire module for autoclicker

### DIFF
--- a/keyboards/ploopyco/trackball/keymaps/viam/config.h
+++ b/keyboards/ploopyco/trackball/keymaps/viam/config.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
 
 #pragma once
 
@@ -27,3 +27,5 @@
 #define PLOOPY_MSGESTURE_ENABLE
 #define BETTER_DRAGSCROLL_TAPDANCE
 #define COMBO_SHOULD_TRIGGER
+#define TURBO_FIRE_KEY_A MS_BTN1
+#define TURBO_FIRE_RATE 40

--- a/keyboards/ploopyco/trackball/keymaps/viam/config.h
+++ b/keyboards/ploopyco/trackball/keymaps/viam/config.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
 #pragma once
 

--- a/keyboards/ploopyco/trackball/keymaps/viam/keymap.c
+++ b/keyboards/ploopyco/trackball/keymaps/viam/keymap.c
@@ -12,7 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
 
 #include QMK_KEYBOARD_H
 
@@ -23,7 +23,7 @@ enum layers {
 };
 
 enum keymap_keycodes {
-    KB_DPI_CONFIG       = QK_KB_0,
+    KB_DPI_CONFIG = QK_KB_0,
     KB_DRAG_SCROLL,
     BETTER_DRAG_SCROLL_MOMENTARY,
     BETTER_DRAG_SCROLL_TOGGLE,
@@ -36,6 +36,8 @@ enum keymap_keycodes {
     BETTER_DRAG_SCROLL_SNIPER_B_TOGGLE,
     BETTER_DRAG_ACTION_A_MOMENTARY,
     BETTER_DRAG_ACTION_B_MOMENTARY,
+    KB_TURBO_A_TOGGLE,
+    KB_TURBO_A_MOMENTARY,
 };
 
 enum {
@@ -56,16 +58,8 @@ enum {
 #define P_MS4FA LT(_FNA, MS_BTN4)
 #define P_MS5FB LT(_FNB, MS_BTN5)
 
-const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-    [_BASE] = LAYOUT( MS_BTN1, MS_BTN3, MS_BTN2, P_MS4FA, P_MS5FB ),
-    [_FNA] = LAYOUT( PL_TSKP, DPI_CONFIG, PL_TSKN, _______, _______ ),
-    [_FNB] = LAYOUT( PL_TSKP, DPI_CONFIG, PL_TSKN, _______, _______ )
-};
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {[_BASE] = LAYOUT(MS_BTN1, MS_BTN3, MS_BTN2, P_MS4FA, P_MS5FB), [_FNA] = LAYOUT(PL_TSKP, DPI_CONFIG, PL_TSKN, _______, _______), [_FNB] = LAYOUT(PL_TSKP, DPI_CONFIG, PL_TSKN, _______, _______)};
 
 #if defined(ENCODER_MAP_ENABLE)
-const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
-    [_BASE] = {ENCODER_CCW_CW(MS_WHLD, MS_WHLU)},
-    [_FNA] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
-    [_FNB] = {ENCODER_CCW_CW(_______, _______)}
-};
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {[_BASE] = {ENCODER_CCW_CW(MS_WHLD, MS_WHLU)}, [_FNA] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)}, [_FNB] = {ENCODER_CCW_CW(_______, _______)}};
 #endif // ENCODER_MAP_ENABLE

--- a/keyboards/ploopyco/trackball/keymaps/viam/keymap.c
+++ b/keyboards/ploopyco/trackball/keymaps/viam/keymap.c
@@ -12,7 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
 #include QMK_KEYBOARD_H
 
@@ -23,7 +23,7 @@ enum layers {
 };
 
 enum keymap_keycodes {
-    KB_DPI_CONFIG = QK_KB_0,
+    KB_DPI_CONFIG       = QK_KB_0,
     KB_DRAG_SCROLL,
     BETTER_DRAG_SCROLL_MOMENTARY,
     BETTER_DRAG_SCROLL_TOGGLE,
@@ -58,8 +58,16 @@ enum {
 #define P_MS4FA LT(_FNA, MS_BTN4)
 #define P_MS5FB LT(_FNB, MS_BTN5)
 
-const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {[_BASE] = LAYOUT(MS_BTN1, MS_BTN3, MS_BTN2, P_MS4FA, P_MS5FB), [_FNA] = LAYOUT(PL_TSKP, DPI_CONFIG, PL_TSKN, _______, _______), [_FNB] = LAYOUT(PL_TSKP, DPI_CONFIG, PL_TSKN, _______, _______)};
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [_BASE] = LAYOUT( MS_BTN1, MS_BTN3, MS_BTN2, P_MS4FA, P_MS5FB ),
+    [_FNA] = LAYOUT( PL_TSKP, DPI_CONFIG, PL_TSKN, _______, _______ ),
+    [_FNB] = LAYOUT( PL_TSKP, DPI_CONFIG, PL_TSKN, _______, _______ )
+};
 
 #if defined(ENCODER_MAP_ENABLE)
-const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {[_BASE] = {ENCODER_CCW_CW(MS_WHLD, MS_WHLU)}, [_FNA] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)}, [_FNB] = {ENCODER_CCW_CW(_______, _______)}};
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [_BASE] = {ENCODER_CCW_CW(MS_WHLD, MS_WHLU)},
+    [_FNA] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
+    [_FNB] = {ENCODER_CCW_CW(_______, _______)}
+};
 #endif // ENCODER_MAP_ENABLE

--- a/keyboards/ploopyco/trackball/keymaps/viam/keymap.json
+++ b/keyboards/ploopyco/trackball/keymaps/viam/keymap.json
@@ -1,34 +1,35 @@
 {
-    "version": 1,
-    "notes": "Hello",
-    "author": "plodah",
-    "documentation": "...",
-    "keyboard": "ploopyco/trackball",
-    "keymap": "viam",
-    "layout": "LAYOUT",
-    "modules": [
-        "plodah/mouse_jiggler",
-        "plodah/task_switch"
-    ],
-    "config": {
-        "build": {
-            "lto": true
-        },
-        "dynamic_keymap": {
-            "layer_count": 4
-        },
-        "features": {
-            "backlight": false,
-            "combo": true,
-            "console": false,
-            "deferred_exec": true,
-            "encoder_map": true,
-            "rgblight": false,
-            "rgb_matrix": false,
-            "tap_dance": true,
-            "via": true
-        },
-        "keyboard_name": "Trackball | viamenus",
-        "manufacturer": "Ploopy"
-    }
+  "version": 1,
+  "notes": "Hello",
+  "author": "plodah",
+  "documentation": "...",
+  "keyboard": "ploopyco/trackball",
+  "keymap": "viam",
+  "layout": "LAYOUT",
+  "modules": [
+    "plodah/mouse_jiggler",
+    "plodah/task_switch",
+    "plodah/turbo_fire"
+  ],
+  "config": {
+    "build": {
+      "lto": true
+    },
+    "dynamic_keymap": {
+      "layer_count": 4
+    },
+    "features": {
+      "backlight": false,
+      "combo": true,
+      "console": false,
+      "deferred_exec": true,
+      "encoder_map": true,
+      "rgblight": false,
+      "rgb_matrix": false,
+      "tap_dance": true,
+      "via": true
+    },
+    "keyboard_name": "Trackball | viamenus",
+    "manufacturer": "Ploopy"
+  }
 }

--- a/keyboards/ploopyco/trackball/keymaps/viam/keymap.json
+++ b/keyboards/ploopyco/trackball/keymaps/viam/keymap.json
@@ -1,35 +1,35 @@
 {
-  "version": 1,
-  "notes": "Hello",
-  "author": "plodah",
-  "documentation": "...",
-  "keyboard": "ploopyco/trackball",
-  "keymap": "viam",
-  "layout": "LAYOUT",
-  "modules": [
-    "plodah/mouse_jiggler",
-    "plodah/task_switch",
-    "plodah/turbo_fire"
-  ],
-  "config": {
-    "build": {
-      "lto": true
-    },
-    "dynamic_keymap": {
-      "layer_count": 4
-    },
-    "features": {
-      "backlight": false,
-      "combo": true,
-      "console": false,
-      "deferred_exec": true,
-      "encoder_map": true,
-      "rgblight": false,
-      "rgb_matrix": false,
-      "tap_dance": true,
-      "via": true
-    },
-    "keyboard_name": "Trackball | viamenus",
-    "manufacturer": "Ploopy"
-  }
+    "version": 1,
+    "notes": "Hello",
+    "author": "plodah",
+    "documentation": "...",
+    "keyboard": "ploopyco/trackball",
+    "keymap": "viam",
+    "layout": "LAYOUT",
+    "modules": [
+        "plodah/mouse_jiggler",
+        "plodah/task_switch",
+        "plodah/turbo_fire"
+    ],
+    "config": {
+        "build": {
+            "lto": true
+        },
+        "dynamic_keymap": {
+            "layer_count": 4
+        },
+        "features": {
+            "backlight": false,
+            "combo": true,
+            "console": false,
+            "deferred_exec": true,
+            "encoder_map": true,
+            "rgblight": false,
+            "rgb_matrix": false,
+            "tap_dance": true,
+            "via": true
+        },
+        "keyboard_name": "Trackball | viamenus",
+        "manufacturer": "Ploopy"
+    }
 }

--- a/users/viam/0_process_record_user.c
+++ b/users/viam/0_process_record_user.c
@@ -1,33 +1,44 @@
 #pragma once
 
+bool process_record_turbo_fire(uint16_t keycode, keyrecord_t *record);
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-
-  #if defined(BETTER_DRAGSCROLL)
+#if defined(BETTER_DRAGSCROLL)
     process_record_better_dragscroll(keycode, record);
-  #endif // defined(BETTER_DRAGSCROLL)
+#endif // defined(BETTER_DRAGSCROLL)
 
-  #if defined(PLOOPY_MSGESTURE_ENABLE) && defined(DEFERRED_EXEC_ENABLE)
+#if defined(PLOOPY_MSGESTURE_ENABLE) && defined(DEFERRED_EXEC_ENABLE)
     process_record_msGesture();
-  #endif // defined(PLOOPY_MSGESTURE_ENABLE) && defined(DEFERRED_EXEC_ENABLE)
+#endif // defined(PLOOPY_MSGESTURE_ENABLE) && defined(DEFERRED_EXEC_ENABLE)
 
-  switch (keycode) {
+    switch (keycode) {
+#if defined(COMMUNITY_MODULE_MOUSE_JIGGLER_ENABLE)
+        case PL_MSJG:
+            // jiggler_toggle();
+            process_record_mouse_jiggler(COMMUNITY_MODULE_MOUSE_JIGGLER_TOGGLE, record);
+            return false;
+#endif // defined(COMMUNITY_MODULE_MOUSE_JIGGLER_ENABLE)
 
-    #if defined(COMMUNITY_MODULE_MOUSE_JIGGLER_ENABLE)
-      case PL_MSJG:
-        // jiggler_toggle();
-        process_record_mouse_jiggler(COMMUNITY_MODULE_MOUSE_JIGGLER_TOGGLE, record);
-        return false;
-    #endif // defined(COMMUNITY_MODULE_MOUSE_JIGGLER_ENABLE)
+#if defined(COMMUNITY_MODULE_TASK_SWITCH_ENABLE)
+        case PL_TSKN:
+            process_record_task_switch(COMMUNITY_MODULE_TASK_SWITCH_NEXT, record);
+            return false;
+        case PL_TSKP:
+            process_record_task_switch(COMMUNITY_MODULE_TASK_SWITCH_PREVIOUS, record);
+            return false;
+#endif // defined(COMMUNITY_MODULE_TASK_SWITCH_ENABLE)
 
-    #if defined(COMMUNITY_MODULE_TASK_SWITCH_ENABLE)
-      case PL_TSKN:
-        process_record_task_switch(COMMUNITY_MODULE_TASK_SWITCH_NEXT, record);
-        return false;
-      case PL_TSKP:
-        process_record_task_switch(COMMUNITY_MODULE_TASK_SWITCH_PREVIOUS, record);
-        return false;
-    #endif // defined(COMMUNITY_MODULE_TASK_SWITCH_ENABLE)
+#if defined(COMMUNITY_MODULE_TURBO_FIRE_ENABLE)
+        case KB_TURBO_A_TOGGLE:
+            // Map keyboard-level key to turbo_fire module keycode (toggle behavior)
+            process_record_turbo_fire(COMMUNITY_MODULE_TURBO_A_TOGGLE, record);
+            return false;
 
-  }
-  return true;
+        case KB_TURBO_A_MOMENTARY:
+            // Map keyboard-level key to turbo_fire module keycode (hold-to-spam)
+            process_record_turbo_fire(COMMUNITY_MODULE_TURBO_A_MOMENTARY, record);
+            return false;
+#endif // defined(COMMUNITY_MODULE_TURBO_FIRE_ENABLE)
+    }
+    return true;
 }

--- a/users/viam/0_process_record_user.c
+++ b/users/viam/0_process_record_user.c
@@ -1,44 +1,42 @@
 #pragma once
 
 bool process_record_turbo_fire(uint16_t keycode, keyrecord_t *record);
-
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-#if defined(BETTER_DRAGSCROLL)
+
+  #if defined(BETTER_DRAGSCROLL)
     process_record_better_dragscroll(keycode, record);
-#endif // defined(BETTER_DRAGSCROLL)
+  #endif // defined(BETTER_DRAGSCROLL)
 
-#if defined(PLOOPY_MSGESTURE_ENABLE) && defined(DEFERRED_EXEC_ENABLE)
+  #if defined(PLOOPY_MSGESTURE_ENABLE) && defined(DEFERRED_EXEC_ENABLE)
     process_record_msGesture();
-#endif // defined(PLOOPY_MSGESTURE_ENABLE) && defined(DEFERRED_EXEC_ENABLE)
+  #endif // defined(PLOOPY_MSGESTURE_ENABLE) && defined(DEFERRED_EXEC_ENABLE)
 
-    switch (keycode) {
-#if defined(COMMUNITY_MODULE_MOUSE_JIGGLER_ENABLE)
-        case PL_MSJG:
-            // jiggler_toggle();
-            process_record_mouse_jiggler(COMMUNITY_MODULE_MOUSE_JIGGLER_TOGGLE, record);
-            return false;
-#endif // defined(COMMUNITY_MODULE_MOUSE_JIGGLER_ENABLE)
+  switch (keycode) {
 
-#if defined(COMMUNITY_MODULE_TASK_SWITCH_ENABLE)
-        case PL_TSKN:
-            process_record_task_switch(COMMUNITY_MODULE_TASK_SWITCH_NEXT, record);
-            return false;
-        case PL_TSKP:
-            process_record_task_switch(COMMUNITY_MODULE_TASK_SWITCH_PREVIOUS, record);
-            return false;
-#endif // defined(COMMUNITY_MODULE_TASK_SWITCH_ENABLE)
+    #if defined(COMMUNITY_MODULE_MOUSE_JIGGLER_ENABLE)
+      case PL_MSJG:
+        // jiggler_toggle();
+        process_record_mouse_jiggler(COMMUNITY_MODULE_MOUSE_JIGGLER_TOGGLE, record);
+        return false;
+    #endif // defined(COMMUNITY_MODULE_MOUSE_JIGGLER_ENABLE)
 
-#if defined(COMMUNITY_MODULE_TURBO_FIRE_ENABLE)
-        case KB_TURBO_A_TOGGLE:
-            // Map keyboard-level key to turbo_fire module keycode (toggle behavior)
-            process_record_turbo_fire(COMMUNITY_MODULE_TURBO_A_TOGGLE, record);
-            return false;
+    #if defined(COMMUNITY_MODULE_TASK_SWITCH_ENABLE)
+      case PL_TSKN:
+        process_record_task_switch(COMMUNITY_MODULE_TASK_SWITCH_NEXT, record);
+        return false;
+      case PL_TSKP:
+        process_record_task_switch(COMMUNITY_MODULE_TASK_SWITCH_PREVIOUS, record);
+        return false;
+    #endif // defined(COMMUNITY_MODULE_TASK_SWITCH_ENABLE)
 
-        case KB_TURBO_A_MOMENTARY:
-            // Map keyboard-level key to turbo_fire module keycode (hold-to-spam)
-            process_record_turbo_fire(COMMUNITY_MODULE_TURBO_A_MOMENTARY, record);
-            return false;
-#endif // defined(COMMUNITY_MODULE_TURBO_FIRE_ENABLE)
-    }
-    return true;
+    #if defined(COMMUNITY_MODULE_TURBO_FIRE_ENABLE)
+      case KB_TURBO_A_TOGGLE:
+        process_record_turbo_fire(COMMUNITY_MODULE_TURBO_A_TOGGLE, record);
+        return false;
+      case KB_TURBO_A_MOMENTARY:
+        process_record_turbo_fire(COMMUNITY_MODULE_TURBO_A_MOMENTARY, record);
+        return false;
+    #endif // defined(COMMUNITY_MODULE_TURBO_FIRE_ENABLE)
+  }
+  return true;
 }

--- a/via_json/trackball.json
+++ b/via_json/trackball.json
@@ -1,521 +1,1276 @@
 {
-    "name": "PloopyCo Trackball",
-    "vendorId": "0x5043",
-    "productId": "0x5442",
-    "matrix": {
-      "rows": 1,
-      "cols": 5
+  "name": "PloopyCo Trackball",
+  "vendorId": "0x5043",
+  "productId": "0x5442",
+  "matrix": {
+    "rows": 1,
+    "cols": 5
+  },
+  "customKeycodes": [
+    {
+      "name": "DPI Config",
+      "title": "DPI Config",
+      "shortName": "DPI"
     },
-    "customKeycodes": [
-        { "name": "DPI Config", "title": "DPI Config", "shortName": "DPI" },
-        { "name": "Ploopy Drag Scroll", "title": "Ploopy Drag Scroll", "shortName": "DragScl" },
-        { "name": "Better DragSc Moment", "title": "Better Drag Scroll Momentary", "shortName": "Drg Mo" },
-        { "name": "Better DragSc Toggle", "title": "Better Drag Scroll Toggle", "shortName": "Drg Tg" },
-        { "name": "Mouse Jiggler Toggle", "title": "Mouse Jiggler Toggle", "shortName": "MsJig" },
-        { "name": "Task Switch Next", "title": "Task Switcher Next", "shortName": "Tsk N" },
-        { "name": "Task Switch Prev", "title": "Task Switcher Previous", "shortName": "Tsk P" },
-        { "name": "Sniper A Mo", "title": "Sniper A Momentary", "shortName": "SnpA Mo" },
-        { "name": "Sniper A Tg", "title": "Sniper A Toggle", "shortName": "SnpA Tg" },
-        { "name": "Sniper B Mo", "title": "Sniper B Momentary", "shortName": "SnpB Mo" },
-        { "name": "Sniper B Tg", "title": "Sniper B Toggle", "shortName": "SnpB Tg" },
-        { "name": "Better DragSc Act A", "title": "Better Drag Scroll Action A", "shortName": "Drg AcA" },
-        { "name": "Better DragSc Act B", "title": "Better Drag Scroll Action B", "shortName": "Drg AcB" }
+    {
+      "name": "Ploopy Drag Scroll",
+      "title": "Ploopy Drag Scroll",
+      "shortName": "DragScl"
+    },
+    {
+      "name": "Better DragSc Moment",
+      "title": "Better Drag Scroll Momentary",
+      "shortName": "Drg Mo"
+    },
+    {
+      "name": "Better DragSc Toggle",
+      "title": "Better Drag Scroll Toggle",
+      "shortName": "Drg Tg"
+    },
+    {
+      "name": "Mouse Jiggler Toggle",
+      "title": "Mouse Jiggler Toggle",
+      "shortName": "MsJig"
+    },
+    {
+      "name": "Task Switch Next",
+      "title": "Task Switcher Next",
+      "shortName": "Tsk N"
+    },
+    {
+      "name": "Task Switch Prev",
+      "title": "Task Switcher Previous",
+      "shortName": "Tsk P"
+    },
+    {
+      "name": "Sniper A Mo",
+      "title": "Sniper A Momentary",
+      "shortName": "SnpA Mo"
+    },
+    {
+      "name": "Sniper A Tg",
+      "title": "Sniper A Toggle",
+      "shortName": "SnpA Tg"
+    },
+    {
+      "name": "Sniper B Mo",
+      "title": "Sniper B Momentary",
+      "shortName": "SnpB Mo"
+    },
+    {
+      "name": "Sniper B Tg",
+      "title": "Sniper B Toggle",
+      "shortName": "SnpB Tg"
+    },
+    {
+      "name": "Better DragSc Act A",
+      "title": "Better Drag Scroll Action A",
+      "shortName": "Drg AcA"
+    },
+    {
+      "name": "Better DragSc Act B",
+      "title": "Better Drag Scroll Action B",
+      "shortName": "Drg AcB"
+    },
+    {
+      "name": "Turbo A Tg",
+      "title": "Turbo A Toggle",
+      "shortName": "TbA Tg"
+    },
+    {
+      "name": "Turbo A Mo",
+      "title": "Turbo A Momentary",
+      "shortName": "TbA Mo"
+    }
+  ],
+  "layouts": {
+    "labels": [
+      [
+        "Show wheel as",
+        "Encoder",
+        "Button"
+      ]
     ],
-    "layouts": {
-        "labels": [
-            [
-                "Show wheel as",
-                "Encoder",
-                "Button"
-            ]
-        ],
-        "keymap": [
-            [
-                {
-                    "h": 2
-                },
-                "0,0",
-                {
-                    "x": 1.5,
-                    "h": 2
-                },
-                "0,2",
-                {
-                    "x": 0.5,
-                    "h": 2
-                },
-                "0,3",
-                {
-                    "h": 2
-                },
-                "0,4"
-            ],
-            [
-                {
-                    "y": -0.75,
-                    "x": 1,
-                    "w": 1.5,
-                    "h": 1.5
-                },
-                "0,1\n\n\n0,0\n\n\n\n\n\ne0"
-            ],
-            [
-                {
-                    "y": 1,
-                    "x": 1,
-                    "w": 1.5,
-                    "h": 1.5,
-                    "d": true
-                },
-                "\n\n\n0,1",
-                {
-                    "x": -1.25,
-                    "h": 1.5
-                },
-                "0,1\n\n\n0,1"
-            ]
-        ]
-    },
-    "menus": [
+    "keymap": [
+      [
         {
-            "label": "Ploopy Stuff",
-            "content": [
-                {
-                    "label": "Settings",
-                    "content": [
-                        {
-                            "label": "Active DPI Preset",
-                            "type": "dropdown",
-                            "options": [
-                                ["1", 0],
-                                ["2", 1],
-                                ["3", 2],
-                                ["4", 3],
-                                ["5", 4]
-                            ],
-                            "content": ["id_ploopystuff_dpi_activepreset", 0, 1]
-                        },
-                        {
-                            "label": "DPI Multiplier",
-                            "type": "dropdown",
-                            "options": [
-                                ["0.25x", 5],
-                                ["0.5x", 10],
-                                ["0.75x", 15],
-                                ["1x", 20],
-                                ["1.25x", 25],
-                                ["1.5x", 30],
-                                ["1.75x", 35],
-                                ["2x", 40],
-                                ["2.5x", 50],
-                                ["3x", 60],
-                                ["4x", 80],
-                                ["5x", 100]
-                            ],
-                            "content": ["id_ploopystuff_dpi_multiplier", 0, 2]
-                        },
-                        {
-                            "label": "Mouse Jiggler",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_msjiggler_enabled", 0, 3]
-                        },
-                        {
-                            "label": "Pointer Invert X",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_pointer_invert_h", 0, 4]
-                        },
-                        {
-                            "label": "Pointer Invert Y",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_pointer_invert_v", 0, 5]
-                        }
-                    ]
-                },
-                {
-                    "label": "Gestures",
-                    "content": [
-                        {
-                            "label": "Wiggleball Wiggle Count",
-                            "type": "dropdown",
-                            "options": [
-                                ["2", 2],
-                                ["3", 3],
-                                ["4", 4],
-                                ["5", 5],
-                                ["6", 6],
-                                ["7", 7],
-                                ["8", 8],
-                                ["9", 9],
-                                ["10", 10]
-                            ],
-                            "content": ["id_ploopystuff_gesture_count", 0, 11]
-                        },
-                        {
-                            "label": "Wiggleball H",
-                            "type": "dropdown",
-                            "options": [
-                                ["Do Nothing", 0],
-                                ["Dragscroll", 1],
-                                ["Mouse Jiggler", 2]
-                            ],
-                            "content": ["id_ploopystuff_gesture_action_h", 0, 12]
-                        },
-                        {
-                            "label": "Wiggleball V",
-                            "type": "dropdown",
-                            "options": [
-                                ["Do Nothing", 0],
-                                ["Dragscroll", 1],
-                                ["Mouse Jiggler", 2]
-                            ],
-                            "content": ["id_ploopystuff_gesture_action_v", 0, 13]
-                        },
-                        {
-                            "label": "Combos Enable",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_combos_enabled", 0, 14]
-                        }
-                    ]
-                },
-                {
-                    "label": "Dragscroll",
-                    "content": [
-                        {
-                            "label": "Dragscroll Divisor X",
-                            "type": "dropdown",
-                            "options": [
-                                ["Off", 0],
-                                ["1", 4],
-                                ["1.5", 6],
-                                ["2", 8],
-                                ["2.5", 10],
-                                ["3", 12],
-                                ["3.5", 14],
-                                ["4", 16],
-                                ["4.5", 18],
-                                ["5", 20],
-                                ["6", 24],
-                                ["7", 28],
-                                ["8", 32],
-                                ["10", 40],
-                                ["12", 48],
-                                ["16", 64],
-                                ["20", 80],
-                                ["24", 96],
-                                ["32", 128],
-                                ["48", 192],
-                                ["64", 255]
-                            ],
-                            "content": ["id_ploopystuff_dragscroll_divisor_h", 0, 23]
-                        },
-                        {
-                            "label": "Dragscroll Divisor Y",
-                            "type": "dropdown",
-                            "options": [
-                                ["Off", 0],
-                                ["1", 4],
-                                ["1.5", 6],
-                                ["2", 8],
-                                ["2.5", 10],
-                                ["3", 12],
-                                ["3.5", 14],
-                                ["4", 16],
-                                ["4.5", 18],
-                                ["5", 20],
-                                ["6", 24],
-                                ["7", 28],
-                                ["8", 32],
-                                ["10", 40],
-                                ["12", 48],
-                                ["16", 64],
-                                ["20", 80],
-                                ["24", 96],
-                                ["32", 128],
-                                ["48", 192],
-                                ["64", 255]
-                            ],
-                            "content": ["id_ploopystuff_dragscroll_divisor_v", 0, 24]
-                        },
-                        {
-                            "label": "Dragscroll Invert X",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_dragscroll_invert_h", 0, 21]
-                        },
-                        {
-                            "label": "Dragscroll Invert Y",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_dragscroll_invert_v", 0, 22]
-                        },
-                        {
-                            "label": "Dragscroll Straighten",
-                            "type": "dropdown",
-                            "options": [
-                                ["Off",    0],
-                                ["25%",   25],
-                                ["50%",   50],
-                                ["75%",   75],
-                                ["85%",   85],
-                                ["90%",   90],
-                                ["95%",   95],
-                                ["100%", 100]
-                            ],
-                            "content": ["id_ploopystuff_dragscroll_straighten_enabled", 0, 51]
-                        }
-                    ]
-                },
-                {
-                    "label": "Moar Dragscroll",
-                    "content": [
-                        {
-                            "label": "Dragscroll on Caps Lock",
-                            "type": "dropdown",
-                            "options": [
-                                ["Off", 0],
-                                ["Scroll while enabled", 1],
-                                ["Scroll while disabled", 2]
-                            ],
-                            "content": ["id_ploopystuff_dragscroll_caps", 0, 25]
-                        },
-                        {
-                            "label": "Dragscroll on Num Lock",
-                            "type": "dropdown",
-                            "options": [
-                                ["Off", 0],
-                                ["Scroll while enabled", 1],
-                                ["Scroll while disabled", 2]
-                            ],
-                            "content": ["id_ploopystuff_dragscroll_num", 0, 26]
-                        },
-                        {
-                            "label": "Dragscroll on Scroll Lock",
-                            "type": "dropdown",
-                            "options": [
-                                ["Off", 0],
-                                ["Scroll while enabled", 1],
-                                ["Scroll while disabled", 2]
-                            ],
-                            "content": ["id_ploopystuff_dragscroll_scroll", 0, 27]
-                        },
-                        {
-                            "label": "Dragscroll on Permanently",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_dragscroll_permanently", 0, 29]
-                        },
-                        {
-                            "label": "Dragscroll end on keypress",
-                            "type": "toggle",
-                            "content": ["id_ploopystuff_dragscroll_end_on_keypress", 0, 28]
-                        }
-                    ]
-                },
-                {
-                    "label": "DPI Presets",
-                    "content": [
-                        {
-                            "label": "Preset 1",
-                            "type": "dropdown",
-                            "options": [
-                                ["100", 10],
-                                ["200", 20],
-                                ["300", 30],
-                                ["400", 40],
-                                ["500", 50],
-                                ["600", 60],
-                                ["700", 70],
-                                ["800", 80],
-                                ["900", 90],
-                                ["1000", 100],
-                                ["1200", 120],
-                                ["1400", 140],
-                                ["1600", 160],
-                                ["2000", 200],
-                                ["2400", 240]
-                            ],
-                            "content": ["id_ploopystuff_dpi_presets[0]", 0, 31, 0]
-                        },
-                        {
-                            "label": "Preset 2",
-                            "type": "dropdown",
-                            "options": [
-                                ["100", 10],
-                                ["200", 20],
-                                ["300", 30],
-                                ["400", 40],
-                                ["500", 50],
-                                ["600", 60],
-                                ["700", 70],
-                                ["800", 80],
-                                ["900", 90],
-                                ["1000", 100],
-                                ["1200", 120],
-                                ["1400", 140],
-                                ["1600", 160],
-                                ["2000", 200],
-                                ["2400", 240]
-                            ],
-                            "content": ["id_ploopystuff_dpi_presets[1]", 0, 31, 1]
-                        },
-                        {
-                            "label": "Preset 3",
-                            "type": "dropdown",
-                            "options": [
-                                ["100", 10],
-                                ["200", 20],
-                                ["300", 30],
-                                ["400", 40],
-                                ["500", 50],
-                                ["600", 60],
-                                ["700", 70],
-                                ["800", 80],
-                                ["900", 90],
-                                ["1000", 100],
-                                ["1200", 120],
-                                ["1400", 140],
-                                ["1600", 160],
-                                ["2000", 200],
-                                ["2400", 240]
-                            ],
-                            "content": ["id_ploopystuff_dpi_presets[2]", 0, 31, 2]
-                        },
-                        {
-                            "label": "Preset 4",
-                            "type": "dropdown",
-                            "options": [
-                                ["100", 10],
-                                ["200", 20],
-                                ["300", 30],
-                                ["400", 40],
-                                ["500", 50],
-                                ["600", 60],
-                                ["700", 70],
-                                ["800", 80],
-                                ["900", 90],
-                                ["1000", 100],
-                                ["1200", 120],
-                                ["1400", 140],
-                                ["1600", 160],
-                                ["2000", 200],
-                                ["2400", 240]
-                            ],
-                            "content": ["id_ploopystuff_dpi_presets[3]", 0, 31, 3]
-                        },
-                        {
-                            "label": "Preset 5",
-                            "type": "dropdown",
-                            "options": [
-                                ["100", 10],
-                                ["200", 20],
-                                ["300", 30],
-                                ["400", 40],
-                                ["500", 50],
-                                ["600", 60],
-                                ["700", 70],
-                                ["800", 80],
-                                ["900", 90],
-                                ["1000", 100],
-                                ["1200", 120],
-                                ["1400", 140],
-                                ["1600", 160],
-                                ["2000", 200],
-                                ["2400", 240]
-                            ],
-                            "content": ["id_ploopystuff_dpi_presets[4]", 0, 31, 4]
-                        }
-                    ]
-                },
-                {
-                    "label": "Sniper DPIs",
-                    "content": [
-                        {
-                            "label": "Sniper DPI A",
-                            "type": "dropdown",
-                            "options": [
-                                ["100", 10],
-                                ["150", 15],
-                                ["200", 20],
-                                ["250", 25],
-                                ["300", 30],
-                                ["350", 35],
-                                ["400", 40],
-                                ["450", 45],
-                                ["500", 50]
-                            ],
-                            "content": ["id_ploopystuff_sniper_a_dpi", 0, 41]
-                        },
-                        {
-                            "label": "Sniper DPI B",
-                            "type": "dropdown",
-                            "options": [
-                                ["100", 10],
-                                ["150", 15],
-                                ["200", 20],
-                                ["250", 25],
-                                ["300", 30],
-                                ["350", 35],
-                                ["400", 40],
-                                ["450", 45],
-                                ["500", 50]
-                            ],
-                            "content": ["id_ploopystuff_sniper_b_dpi", 0, 42]
-                        }
-                    ]
-                }
-            ]
+          "h": 2
+        },
+        "0,0",
+        {
+          "x": 1.5,
+          "h": 2
+        },
+        "0,2",
+        {
+          "x": 0.5,
+          "h": 2
+        },
+        "0,3",
+        {
+          "h": 2
+        },
+        "0,4"
+      ],
+      [
+        {
+          "y": -0.75,
+          "x": 1,
+          "w": 1.5,
+          "h": 1.5
+        },
+        "0,1\n\n\n0,0\n\n\n\n\n\ne0"
+      ],
+      [
+        {
+          "y": 1,
+          "x": 1,
+          "w": 1.5,
+          "h": 1.5,
+          "d": true
+        },
+        "\n\n\n0,1",
+        {
+          "x": -1.25,
+          "h": 1.5
+        },
+        "0,1\n\n\n0,1"
+      ]
+    ]
+  },
+  "menus": [
+    {
+      "label": "Ploopy Stuff",
+      "content": [
+        {
+          "label": "Settings",
+          "content": [
+            {
+              "label": "Active DPI Preset",
+              "type": "dropdown",
+              "options": [
+                [
+                  "1",
+                  0
+                ],
+                [
+                  "2",
+                  1
+                ],
+                [
+                  "3",
+                  2
+                ],
+                [
+                  "4",
+                  3
+                ],
+                [
+                  "5",
+                  4
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dpi_activepreset",
+                0,
+                1
+              ]
+            },
+            {
+              "label": "DPI Multiplier",
+              "type": "dropdown",
+              "options": [
+                [
+                  "0.25x",
+                  5
+                ],
+                [
+                  "0.5x",
+                  10
+                ],
+                [
+                  "0.75x",
+                  15
+                ],
+                [
+                  "1x",
+                  20
+                ],
+                [
+                  "1.25x",
+                  25
+                ],
+                [
+                  "1.5x",
+                  30
+                ],
+                [
+                  "1.75x",
+                  35
+                ],
+                [
+                  "2x",
+                  40
+                ],
+                [
+                  "2.5x",
+                  50
+                ],
+                [
+                  "3x",
+                  60
+                ],
+                [
+                  "4x",
+                  80
+                ],
+                [
+                  "5x",
+                  100
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dpi_multiplier",
+                0,
+                2
+              ]
+            },
+            {
+              "label": "Mouse Jiggler",
+              "type": "toggle",
+              "content": [
+                "id_ploopystuff_msjiggler_enabled",
+                0,
+                3
+              ]
+            },
+            {
+              "label": "Pointer Invert X",
+              "type": "toggle",
+              "content": [
+                "id_ploopystuff_pointer_invert_h",
+                0,
+                4
+              ]
+            },
+            {
+              "label": "Pointer Invert Y",
+              "type": "toggle",
+              "content": [
+                "id_ploopystuff_pointer_invert_v",
+                0,
+                5
+              ]
+            }
+          ]
         },
         {
-            "label": "DragActions",
-            "content": [
-                {
-                    "label": "DragAction A",
-                    "content": [
-                        {
-                            "label": "Up",
-                            "type": "keycode",
-                            "content": ["id_ploopystuff_dragscroll_dragact_a_up", 0, 61]
-                        },
-                        {
-                            "label": "Down",
-                            "type": "keycode",
-                            "content": ["id_ploopystuff_dragscroll_dragact_a_down", 0, 62]
-                        },
-                        {
-                            "label": "Left",
-                            "type": "keycode",
-                            "content": ["id_ploopystuff_dragscroll_dragact_a_left", 0, 63]
-                        },
-                        {
-                            "label": "Right",
-                            "type": "keycode",
-                            "content": ["id_ploopystuff_dragscroll_dragact_a_right", 0, 64]
-                        }
-                    ]
-                },
-                {
-                    "label": "DragAction B",
-                    "content": [
-                        {
-                            "label": "Up",
-                            "type": "keycode",
-                            "content": ["id_ploopystuff_dragscroll_dragact_b_up", 0, 65]
-                        },
-                        {
-                            "label": "Down",
-                            "type": "keycode",
-                            "content": ["id_ploopystuff_dragscroll_dragact_b_down", 0, 66]
-                        },
-                        {
-                            "label": "Left",
-                            "type": "keycode",
-                            "content": ["id_ploopystuff_dragscroll_dragact_b_left", 0, 67]
-                        },
-                        {
-                            "label": "Right",
-                            "type": "keycode",
-                            "content": ["id_ploopystuff_dragscroll_dragact_b_right", 0, 68]
-                        }
-                    ]
-                }
-            ]
+          "label": "Gestures",
+          "content": [
+            {
+              "label": "Wiggleball Wiggle Count",
+              "type": "dropdown",
+              "options": [
+                [
+                  "2",
+                  2
+                ],
+                [
+                  "3",
+                  3
+                ],
+                [
+                  "4",
+                  4
+                ],
+                [
+                  "5",
+                  5
+                ],
+                [
+                  "6",
+                  6
+                ],
+                [
+                  "7",
+                  7
+                ],
+                [
+                  "8",
+                  8
+                ],
+                [
+                  "9",
+                  9
+                ],
+                [
+                  "10",
+                  10
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_gesture_count",
+                0,
+                11
+              ]
+            },
+            {
+              "label": "Wiggleball H",
+              "type": "dropdown",
+              "options": [
+                [
+                  "Do Nothing",
+                  0
+                ],
+                [
+                  "Dragscroll",
+                  1
+                ],
+                [
+                  "Mouse Jiggler",
+                  2
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_gesture_action_h",
+                0,
+                12
+              ]
+            },
+            {
+              "label": "Wiggleball V",
+              "type": "dropdown",
+              "options": [
+                [
+                  "Do Nothing",
+                  0
+                ],
+                [
+                  "Dragscroll",
+                  1
+                ],
+                [
+                  "Mouse Jiggler",
+                  2
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_gesture_action_v",
+                0,
+                13
+              ]
+            },
+            {
+              "label": "Combos Enable",
+              "type": "toggle",
+              "content": [
+                "id_ploopystuff_combos_enabled",
+                0,
+                14
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Dragscroll",
+          "content": [
+            {
+              "label": "Dragscroll Divisor X",
+              "type": "dropdown",
+              "options": [
+                [
+                  "Off",
+                  0
+                ],
+                [
+                  "1",
+                  4
+                ],
+                [
+                  "1.5",
+                  6
+                ],
+                [
+                  "2",
+                  8
+                ],
+                [
+                  "2.5",
+                  10
+                ],
+                [
+                  "3",
+                  12
+                ],
+                [
+                  "3.5",
+                  14
+                ],
+                [
+                  "4",
+                  16
+                ],
+                [
+                  "4.5",
+                  18
+                ],
+                [
+                  "5",
+                  20
+                ],
+                [
+                  "6",
+                  24
+                ],
+                [
+                  "7",
+                  28
+                ],
+                [
+                  "8",
+                  32
+                ],
+                [
+                  "10",
+                  40
+                ],
+                [
+                  "12",
+                  48
+                ],
+                [
+                  "16",
+                  64
+                ],
+                [
+                  "20",
+                  80
+                ],
+                [
+                  "24",
+                  96
+                ],
+                [
+                  "32",
+                  128
+                ],
+                [
+                  "48",
+                  192
+                ],
+                [
+                  "64",
+                  255
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dragscroll_divisor_h",
+                0,
+                23
+              ]
+            },
+            {
+              "label": "Dragscroll Divisor Y",
+              "type": "dropdown",
+              "options": [
+                [
+                  "Off",
+                  0
+                ],
+                [
+                  "1",
+                  4
+                ],
+                [
+                  "1.5",
+                  6
+                ],
+                [
+                  "2",
+                  8
+                ],
+                [
+                  "2.5",
+                  10
+                ],
+                [
+                  "3",
+                  12
+                ],
+                [
+                  "3.5",
+                  14
+                ],
+                [
+                  "4",
+                  16
+                ],
+                [
+                  "4.5",
+                  18
+                ],
+                [
+                  "5",
+                  20
+                ],
+                [
+                  "6",
+                  24
+                ],
+                [
+                  "7",
+                  28
+                ],
+                [
+                  "8",
+                  32
+                ],
+                [
+                  "10",
+                  40
+                ],
+                [
+                  "12",
+                  48
+                ],
+                [
+                  "16",
+                  64
+                ],
+                [
+                  "20",
+                  80
+                ],
+                [
+                  "24",
+                  96
+                ],
+                [
+                  "32",
+                  128
+                ],
+                [
+                  "48",
+                  192
+                ],
+                [
+                  "64",
+                  255
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dragscroll_divisor_v",
+                0,
+                24
+              ]
+            },
+            {
+              "label": "Dragscroll Invert X",
+              "type": "toggle",
+              "content": [
+                "id_ploopystuff_dragscroll_invert_h",
+                0,
+                21
+              ]
+            },
+            {
+              "label": "Dragscroll Invert Y",
+              "type": "toggle",
+              "content": [
+                "id_ploopystuff_dragscroll_invert_v",
+                0,
+                22
+              ]
+            },
+            {
+              "label": "Dragscroll Straighten",
+              "type": "dropdown",
+              "options": [
+                [
+                  "Off",
+                  0
+                ],
+                [
+                  "25%",
+                  25
+                ],
+                [
+                  "50%",
+                  50
+                ],
+                [
+                  "75%",
+                  75
+                ],
+                [
+                  "85%",
+                  85
+                ],
+                [
+                  "90%",
+                  90
+                ],
+                [
+                  "95%",
+                  95
+                ],
+                [
+                  "100%",
+                  100
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dragscroll_straighten_enabled",
+                0,
+                51
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Moar Dragscroll",
+          "content": [
+            {
+              "label": "Dragscroll on Caps Lock",
+              "type": "dropdown",
+              "options": [
+                [
+                  "Off",
+                  0
+                ],
+                [
+                  "Scroll while enabled",
+                  1
+                ],
+                [
+                  "Scroll while disabled",
+                  2
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dragscroll_caps",
+                0,
+                25
+              ]
+            },
+            {
+              "label": "Dragscroll on Num Lock",
+              "type": "dropdown",
+              "options": [
+                [
+                  "Off",
+                  0
+                ],
+                [
+                  "Scroll while enabled",
+                  1
+                ],
+                [
+                  "Scroll while disabled",
+                  2
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dragscroll_num",
+                0,
+                26
+              ]
+            },
+            {
+              "label": "Dragscroll on Scroll Lock",
+              "type": "dropdown",
+              "options": [
+                [
+                  "Off",
+                  0
+                ],
+                [
+                  "Scroll while enabled",
+                  1
+                ],
+                [
+                  "Scroll while disabled",
+                  2
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dragscroll_scroll",
+                0,
+                27
+              ]
+            },
+            {
+              "label": "Dragscroll on Permanently",
+              "type": "toggle",
+              "content": [
+                "id_ploopystuff_dragscroll_permanently",
+                0,
+                29
+              ]
+            },
+            {
+              "label": "Dragscroll end on keypress",
+              "type": "toggle",
+              "content": [
+                "id_ploopystuff_dragscroll_end_on_keypress",
+                0,
+                28
+              ]
+            }
+          ]
+        },
+        {
+          "label": "DPI Presets",
+          "content": [
+            {
+              "label": "Preset 1",
+              "type": "dropdown",
+              "options": [
+                [
+                  "100",
+                  10
+                ],
+                [
+                  "200",
+                  20
+                ],
+                [
+                  "300",
+                  30
+                ],
+                [
+                  "400",
+                  40
+                ],
+                [
+                  "500",
+                  50
+                ],
+                [
+                  "600",
+                  60
+                ],
+                [
+                  "700",
+                  70
+                ],
+                [
+                  "800",
+                  80
+                ],
+                [
+                  "900",
+                  90
+                ],
+                [
+                  "1000",
+                  100
+                ],
+                [
+                  "1200",
+                  120
+                ],
+                [
+                  "1400",
+                  140
+                ],
+                [
+                  "1600",
+                  160
+                ],
+                [
+                  "2000",
+                  200
+                ],
+                [
+                  "2400",
+                  240
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dpi_presets[0]",
+                0,
+                31,
+                0
+              ]
+            },
+            {
+              "label": "Preset 2",
+              "type": "dropdown",
+              "options": [
+                [
+                  "100",
+                  10
+                ],
+                [
+                  "200",
+                  20
+                ],
+                [
+                  "300",
+                  30
+                ],
+                [
+                  "400",
+                  40
+                ],
+                [
+                  "500",
+                  50
+                ],
+                [
+                  "600",
+                  60
+                ],
+                [
+                  "700",
+                  70
+                ],
+                [
+                  "800",
+                  80
+                ],
+                [
+                  "900",
+                  90
+                ],
+                [
+                  "1000",
+                  100
+                ],
+                [
+                  "1200",
+                  120
+                ],
+                [
+                  "1400",
+                  140
+                ],
+                [
+                  "1600",
+                  160
+                ],
+                [
+                  "2000",
+                  200
+                ],
+                [
+                  "2400",
+                  240
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dpi_presets[1]",
+                0,
+                31,
+                1
+              ]
+            },
+            {
+              "label": "Preset 3",
+              "type": "dropdown",
+              "options": [
+                [
+                  "100",
+                  10
+                ],
+                [
+                  "200",
+                  20
+                ],
+                [
+                  "300",
+                  30
+                ],
+                [
+                  "400",
+                  40
+                ],
+                [
+                  "500",
+                  50
+                ],
+                [
+                  "600",
+                  60
+                ],
+                [
+                  "700",
+                  70
+                ],
+                [
+                  "800",
+                  80
+                ],
+                [
+                  "900",
+                  90
+                ],
+                [
+                  "1000",
+                  100
+                ],
+                [
+                  "1200",
+                  120
+                ],
+                [
+                  "1400",
+                  140
+                ],
+                [
+                  "1600",
+                  160
+                ],
+                [
+                  "2000",
+                  200
+                ],
+                [
+                  "2400",
+                  240
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dpi_presets[2]",
+                0,
+                31,
+                2
+              ]
+            },
+            {
+              "label": "Preset 4",
+              "type": "dropdown",
+              "options": [
+                [
+                  "100",
+                  10
+                ],
+                [
+                  "200",
+                  20
+                ],
+                [
+                  "300",
+                  30
+                ],
+                [
+                  "400",
+                  40
+                ],
+                [
+                  "500",
+                  50
+                ],
+                [
+                  "600",
+                  60
+                ],
+                [
+                  "700",
+                  70
+                ],
+                [
+                  "800",
+                  80
+                ],
+                [
+                  "900",
+                  90
+                ],
+                [
+                  "1000",
+                  100
+                ],
+                [
+                  "1200",
+                  120
+                ],
+                [
+                  "1400",
+                  140
+                ],
+                [
+                  "1600",
+                  160
+                ],
+                [
+                  "2000",
+                  200
+                ],
+                [
+                  "2400",
+                  240
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dpi_presets[3]",
+                0,
+                31,
+                3
+              ]
+            },
+            {
+              "label": "Preset 5",
+              "type": "dropdown",
+              "options": [
+                [
+                  "100",
+                  10
+                ],
+                [
+                  "200",
+                  20
+                ],
+                [
+                  "300",
+                  30
+                ],
+                [
+                  "400",
+                  40
+                ],
+                [
+                  "500",
+                  50
+                ],
+                [
+                  "600",
+                  60
+                ],
+                [
+                  "700",
+                  70
+                ],
+                [
+                  "800",
+                  80
+                ],
+                [
+                  "900",
+                  90
+                ],
+                [
+                  "1000",
+                  100
+                ],
+                [
+                  "1200",
+                  120
+                ],
+                [
+                  "1400",
+                  140
+                ],
+                [
+                  "1600",
+                  160
+                ],
+                [
+                  "2000",
+                  200
+                ],
+                [
+                  "2400",
+                  240
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_dpi_presets[4]",
+                0,
+                31,
+                4
+              ]
+            }
+          ]
+        },
+        {
+          "label": "Sniper DPIs",
+          "content": [
+            {
+              "label": "Sniper DPI A",
+              "type": "dropdown",
+              "options": [
+                [
+                  "100",
+                  10
+                ],
+                [
+                  "150",
+                  15
+                ],
+                [
+                  "200",
+                  20
+                ],
+                [
+                  "250",
+                  25
+                ],
+                [
+                  "300",
+                  30
+                ],
+                [
+                  "350",
+                  35
+                ],
+                [
+                  "400",
+                  40
+                ],
+                [
+                  "450",
+                  45
+                ],
+                [
+                  "500",
+                  50
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_sniper_a_dpi",
+                0,
+                41
+              ]
+            },
+            {
+              "label": "Sniper DPI B",
+              "type": "dropdown",
+              "options": [
+                [
+                  "100",
+                  10
+                ],
+                [
+                  "150",
+                  15
+                ],
+                [
+                  "200",
+                  20
+                ],
+                [
+                  "250",
+                  25
+                ],
+                [
+                  "300",
+                  30
+                ],
+                [
+                  "350",
+                  35
+                ],
+                [
+                  "400",
+                  40
+                ],
+                [
+                  "450",
+                  45
+                ],
+                [
+                  "500",
+                  50
+                ]
+              ],
+              "content": [
+                "id_ploopystuff_sniper_b_dpi",
+                0,
+                42
+              ]
+            }
+          ]
         }
-    ]
-  }
+      ]
+    },
+    {
+      "label": "DragActions",
+      "content": [
+        {
+          "label": "DragAction A",
+          "content": [
+            {
+              "label": "Up",
+              "type": "keycode",
+              "content": [
+                "id_ploopystuff_dragscroll_dragact_a_up",
+                0,
+                61
+              ]
+            },
+            {
+              "label": "Down",
+              "type": "keycode",
+              "content": [
+                "id_ploopystuff_dragscroll_dragact_a_down",
+                0,
+                62
+              ]
+            },
+            {
+              "label": "Left",
+              "type": "keycode",
+              "content": [
+                "id_ploopystuff_dragscroll_dragact_a_left",
+                0,
+                63
+              ]
+            },
+            {
+              "label": "Right",
+              "type": "keycode",
+              "content": [
+                "id_ploopystuff_dragscroll_dragact_a_right",
+                0,
+                64
+              ]
+            }
+          ]
+        },
+        {
+          "label": "DragAction B",
+          "content": [
+            {
+              "label": "Up",
+              "type": "keycode",
+              "content": [
+                "id_ploopystuff_dragscroll_dragact_b_up",
+                0,
+                65
+              ]
+            },
+            {
+              "label": "Down",
+              "type": "keycode",
+              "content": [
+                "id_ploopystuff_dragscroll_dragact_b_down",
+                0,
+                66
+              ]
+            },
+            {
+              "label": "Left",
+              "type": "keycode",
+              "content": [
+                "id_ploopystuff_dragscroll_dragact_b_left",
+                0,
+                67
+              ]
+            },
+            {
+              "label": "Right",
+              "type": "keycode",
+              "content": [
+                "id_ploopystuff_dragscroll_dragact_b_right",
+                0,
+                68
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/via_json/trackball.json
+++ b/via_json/trackball.json
@@ -1,1276 +1,523 @@
 {
-  "name": "PloopyCo Trackball",
-  "vendorId": "0x5043",
-  "productId": "0x5442",
-  "matrix": {
-    "rows": 1,
-    "cols": 5
-  },
-  "customKeycodes": [
-    {
-      "name": "DPI Config",
-      "title": "DPI Config",
-      "shortName": "DPI"
+    "name": "PloopyCo Trackball",
+    "vendorId": "0x5043",
+    "productId": "0x5442",
+    "matrix": {
+      "rows": 1,
+      "cols": 5
     },
-    {
-      "name": "Ploopy Drag Scroll",
-      "title": "Ploopy Drag Scroll",
-      "shortName": "DragScl"
-    },
-    {
-      "name": "Better DragSc Moment",
-      "title": "Better Drag Scroll Momentary",
-      "shortName": "Drg Mo"
-    },
-    {
-      "name": "Better DragSc Toggle",
-      "title": "Better Drag Scroll Toggle",
-      "shortName": "Drg Tg"
-    },
-    {
-      "name": "Mouse Jiggler Toggle",
-      "title": "Mouse Jiggler Toggle",
-      "shortName": "MsJig"
-    },
-    {
-      "name": "Task Switch Next",
-      "title": "Task Switcher Next",
-      "shortName": "Tsk N"
-    },
-    {
-      "name": "Task Switch Prev",
-      "title": "Task Switcher Previous",
-      "shortName": "Tsk P"
-    },
-    {
-      "name": "Sniper A Mo",
-      "title": "Sniper A Momentary",
-      "shortName": "SnpA Mo"
-    },
-    {
-      "name": "Sniper A Tg",
-      "title": "Sniper A Toggle",
-      "shortName": "SnpA Tg"
-    },
-    {
-      "name": "Sniper B Mo",
-      "title": "Sniper B Momentary",
-      "shortName": "SnpB Mo"
-    },
-    {
-      "name": "Sniper B Tg",
-      "title": "Sniper B Toggle",
-      "shortName": "SnpB Tg"
-    },
-    {
-      "name": "Better DragSc Act A",
-      "title": "Better Drag Scroll Action A",
-      "shortName": "Drg AcA"
-    },
-    {
-      "name": "Better DragSc Act B",
-      "title": "Better Drag Scroll Action B",
-      "shortName": "Drg AcB"
-    },
-    {
-      "name": "Turbo A Tg",
-      "title": "Turbo A Toggle",
-      "shortName": "TbA Tg"
-    },
-    {
-      "name": "Turbo A Mo",
-      "title": "Turbo A Momentary",
-      "shortName": "TbA Mo"
-    }
-  ],
-  "layouts": {
-    "labels": [
-      [
-        "Show wheel as",
-        "Encoder",
-        "Button"
-      ]
+    "customKeycodes": [
+        { "name": "DPI Config", "title": "DPI Config", "shortName": "DPI" },
+        { "name": "Ploopy Drag Scroll", "title": "Ploopy Drag Scroll", "shortName": "DragScl" },
+        { "name": "Better DragSc Moment", "title": "Better Drag Scroll Momentary", "shortName": "Drg Mo" },
+        { "name": "Better DragSc Toggle", "title": "Better Drag Scroll Toggle", "shortName": "Drg Tg" },
+        { "name": "Mouse Jiggler Toggle", "title": "Mouse Jiggler Toggle", "shortName": "MsJig" },
+        { "name": "Task Switch Next", "title": "Task Switcher Next", "shortName": "Tsk N" },
+        { "name": "Task Switch Prev", "title": "Task Switcher Previous", "shortName": "Tsk P" },
+        { "name": "Sniper A Mo", "title": "Sniper A Momentary", "shortName": "SnpA Mo" },
+        { "name": "Sniper A Tg", "title": "Sniper A Toggle", "shortName": "SnpA Tg" },
+        { "name": "Sniper B Mo", "title": "Sniper B Momentary", "shortName": "SnpB Mo" },
+        { "name": "Sniper B Tg", "title": "Sniper B Toggle", "shortName": "SnpB Tg" },
+        { "name": "Better DragSc Act A", "title": "Better Drag Scroll Action A", "shortName": "Drg AcA" },
+        { "name": "Better DragSc Act B", "title": "Better Drag Scroll Action B", "shortName": "Drg AcB" },
+        { "name": "Turbo A Tg", "title": "Turbo A Toggle", "shortName": "TbA Tg" },
+        { "name": "Turbo A Mo", "title": "Turbo A Momentary", "shortName": "TbA Mo" }
     ],
-    "keymap": [
-      [
-        {
-          "h": 2
-        },
-        "0,0",
-        {
-          "x": 1.5,
-          "h": 2
-        },
-        "0,2",
-        {
-          "x": 0.5,
-          "h": 2
-        },
-        "0,3",
-        {
-          "h": 2
-        },
-        "0,4"
-      ],
-      [
-        {
-          "y": -0.75,
-          "x": 1,
-          "w": 1.5,
-          "h": 1.5
-        },
-        "0,1\n\n\n0,0\n\n\n\n\n\ne0"
-      ],
-      [
-        {
-          "y": 1,
-          "x": 1,
-          "w": 1.5,
-          "h": 1.5,
-          "d": true
-        },
-        "\n\n\n0,1",
-        {
-          "x": -1.25,
-          "h": 1.5
-        },
-        "0,1\n\n\n0,1"
-      ]
-    ]
-  },
-  "menus": [
-    {
-      "label": "Ploopy Stuff",
-      "content": [
-        {
-          "label": "Settings",
-          "content": [
-            {
-              "label": "Active DPI Preset",
-              "type": "dropdown",
-              "options": [
-                [
-                  "1",
-                  0
-                ],
-                [
-                  "2",
-                  1
-                ],
-                [
-                  "3",
-                  2
-                ],
-                [
-                  "4",
-                  3
-                ],
-                [
-                  "5",
-                  4
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dpi_activepreset",
-                0,
-                1
-              ]
-            },
-            {
-              "label": "DPI Multiplier",
-              "type": "dropdown",
-              "options": [
-                [
-                  "0.25x",
-                  5
-                ],
-                [
-                  "0.5x",
-                  10
-                ],
-                [
-                  "0.75x",
-                  15
-                ],
-                [
-                  "1x",
-                  20
-                ],
-                [
-                  "1.25x",
-                  25
-                ],
-                [
-                  "1.5x",
-                  30
-                ],
-                [
-                  "1.75x",
-                  35
-                ],
-                [
-                  "2x",
-                  40
-                ],
-                [
-                  "2.5x",
-                  50
-                ],
-                [
-                  "3x",
-                  60
-                ],
-                [
-                  "4x",
-                  80
-                ],
-                [
-                  "5x",
-                  100
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dpi_multiplier",
-                0,
-                2
-              ]
-            },
-            {
-              "label": "Mouse Jiggler",
-              "type": "toggle",
-              "content": [
-                "id_ploopystuff_msjiggler_enabled",
-                0,
-                3
-              ]
-            },
-            {
-              "label": "Pointer Invert X",
-              "type": "toggle",
-              "content": [
-                "id_ploopystuff_pointer_invert_h",
-                0,
-                4
-              ]
-            },
-            {
-              "label": "Pointer Invert Y",
-              "type": "toggle",
-              "content": [
-                "id_ploopystuff_pointer_invert_v",
-                0,
-                5
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Gestures",
-          "content": [
-            {
-              "label": "Wiggleball Wiggle Count",
-              "type": "dropdown",
-              "options": [
-                [
-                  "2",
-                  2
-                ],
-                [
-                  "3",
-                  3
-                ],
-                [
-                  "4",
-                  4
-                ],
-                [
-                  "5",
-                  5
-                ],
-                [
-                  "6",
-                  6
-                ],
-                [
-                  "7",
-                  7
-                ],
-                [
-                  "8",
-                  8
-                ],
-                [
-                  "9",
-                  9
-                ],
-                [
-                  "10",
-                  10
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_gesture_count",
-                0,
-                11
-              ]
-            },
-            {
-              "label": "Wiggleball H",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Do Nothing",
-                  0
-                ],
-                [
-                  "Dragscroll",
-                  1
-                ],
-                [
-                  "Mouse Jiggler",
-                  2
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_gesture_action_h",
-                0,
-                12
-              ]
-            },
-            {
-              "label": "Wiggleball V",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Do Nothing",
-                  0
-                ],
-                [
-                  "Dragscroll",
-                  1
-                ],
-                [
-                  "Mouse Jiggler",
-                  2
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_gesture_action_v",
-                0,
-                13
-              ]
-            },
-            {
-              "label": "Combos Enable",
-              "type": "toggle",
-              "content": [
-                "id_ploopystuff_combos_enabled",
-                0,
-                14
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Dragscroll",
-          "content": [
-            {
-              "label": "Dragscroll Divisor X",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Off",
-                  0
-                ],
-                [
-                  "1",
-                  4
-                ],
-                [
-                  "1.5",
-                  6
-                ],
-                [
-                  "2",
-                  8
-                ],
-                [
-                  "2.5",
-                  10
-                ],
-                [
-                  "3",
-                  12
-                ],
-                [
-                  "3.5",
-                  14
-                ],
-                [
-                  "4",
-                  16
-                ],
-                [
-                  "4.5",
-                  18
-                ],
-                [
-                  "5",
-                  20
-                ],
-                [
-                  "6",
-                  24
-                ],
-                [
-                  "7",
-                  28
-                ],
-                [
-                  "8",
-                  32
-                ],
-                [
-                  "10",
-                  40
-                ],
-                [
-                  "12",
-                  48
-                ],
-                [
-                  "16",
-                  64
-                ],
-                [
-                  "20",
-                  80
-                ],
-                [
-                  "24",
-                  96
-                ],
-                [
-                  "32",
-                  128
-                ],
-                [
-                  "48",
-                  192
-                ],
-                [
-                  "64",
-                  255
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dragscroll_divisor_h",
-                0,
-                23
-              ]
-            },
-            {
-              "label": "Dragscroll Divisor Y",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Off",
-                  0
-                ],
-                [
-                  "1",
-                  4
-                ],
-                [
-                  "1.5",
-                  6
-                ],
-                [
-                  "2",
-                  8
-                ],
-                [
-                  "2.5",
-                  10
-                ],
-                [
-                  "3",
-                  12
-                ],
-                [
-                  "3.5",
-                  14
-                ],
-                [
-                  "4",
-                  16
-                ],
-                [
-                  "4.5",
-                  18
-                ],
-                [
-                  "5",
-                  20
-                ],
-                [
-                  "6",
-                  24
-                ],
-                [
-                  "7",
-                  28
-                ],
-                [
-                  "8",
-                  32
-                ],
-                [
-                  "10",
-                  40
-                ],
-                [
-                  "12",
-                  48
-                ],
-                [
-                  "16",
-                  64
-                ],
-                [
-                  "20",
-                  80
-                ],
-                [
-                  "24",
-                  96
-                ],
-                [
-                  "32",
-                  128
-                ],
-                [
-                  "48",
-                  192
-                ],
-                [
-                  "64",
-                  255
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dragscroll_divisor_v",
-                0,
-                24
-              ]
-            },
-            {
-              "label": "Dragscroll Invert X",
-              "type": "toggle",
-              "content": [
-                "id_ploopystuff_dragscroll_invert_h",
-                0,
-                21
-              ]
-            },
-            {
-              "label": "Dragscroll Invert Y",
-              "type": "toggle",
-              "content": [
-                "id_ploopystuff_dragscroll_invert_v",
-                0,
-                22
-              ]
-            },
-            {
-              "label": "Dragscroll Straighten",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Off",
-                  0
-                ],
-                [
-                  "25%",
-                  25
-                ],
-                [
-                  "50%",
-                  50
-                ],
-                [
-                  "75%",
-                  75
-                ],
-                [
-                  "85%",
-                  85
-                ],
-                [
-                  "90%",
-                  90
-                ],
-                [
-                  "95%",
-                  95
-                ],
-                [
-                  "100%",
-                  100
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dragscroll_straighten_enabled",
-                0,
-                51
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Moar Dragscroll",
-          "content": [
-            {
-              "label": "Dragscroll on Caps Lock",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Off",
-                  0
-                ],
-                [
-                  "Scroll while enabled",
-                  1
-                ],
-                [
-                  "Scroll while disabled",
-                  2
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dragscroll_caps",
-                0,
-                25
-              ]
-            },
-            {
-              "label": "Dragscroll on Num Lock",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Off",
-                  0
-                ],
-                [
-                  "Scroll while enabled",
-                  1
-                ],
-                [
-                  "Scroll while disabled",
-                  2
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dragscroll_num",
-                0,
-                26
-              ]
-            },
-            {
-              "label": "Dragscroll on Scroll Lock",
-              "type": "dropdown",
-              "options": [
-                [
-                  "Off",
-                  0
-                ],
-                [
-                  "Scroll while enabled",
-                  1
-                ],
-                [
-                  "Scroll while disabled",
-                  2
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dragscroll_scroll",
-                0,
-                27
-              ]
-            },
-            {
-              "label": "Dragscroll on Permanently",
-              "type": "toggle",
-              "content": [
-                "id_ploopystuff_dragscroll_permanently",
-                0,
-                29
-              ]
-            },
-            {
-              "label": "Dragscroll end on keypress",
-              "type": "toggle",
-              "content": [
-                "id_ploopystuff_dragscroll_end_on_keypress",
-                0,
-                28
-              ]
-            }
-          ]
-        },
-        {
-          "label": "DPI Presets",
-          "content": [
-            {
-              "label": "Preset 1",
-              "type": "dropdown",
-              "options": [
-                [
-                  "100",
-                  10
-                ],
-                [
-                  "200",
-                  20
-                ],
-                [
-                  "300",
-                  30
-                ],
-                [
-                  "400",
-                  40
-                ],
-                [
-                  "500",
-                  50
-                ],
-                [
-                  "600",
-                  60
-                ],
-                [
-                  "700",
-                  70
-                ],
-                [
-                  "800",
-                  80
-                ],
-                [
-                  "900",
-                  90
-                ],
-                [
-                  "1000",
-                  100
-                ],
-                [
-                  "1200",
-                  120
-                ],
-                [
-                  "1400",
-                  140
-                ],
-                [
-                  "1600",
-                  160
-                ],
-                [
-                  "2000",
-                  200
-                ],
-                [
-                  "2400",
-                  240
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dpi_presets[0]",
-                0,
-                31,
-                0
-              ]
-            },
-            {
-              "label": "Preset 2",
-              "type": "dropdown",
-              "options": [
-                [
-                  "100",
-                  10
-                ],
-                [
-                  "200",
-                  20
-                ],
-                [
-                  "300",
-                  30
-                ],
-                [
-                  "400",
-                  40
-                ],
-                [
-                  "500",
-                  50
-                ],
-                [
-                  "600",
-                  60
-                ],
-                [
-                  "700",
-                  70
-                ],
-                [
-                  "800",
-                  80
-                ],
-                [
-                  "900",
-                  90
-                ],
-                [
-                  "1000",
-                  100
-                ],
-                [
-                  "1200",
-                  120
-                ],
-                [
-                  "1400",
-                  140
-                ],
-                [
-                  "1600",
-                  160
-                ],
-                [
-                  "2000",
-                  200
-                ],
-                [
-                  "2400",
-                  240
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dpi_presets[1]",
-                0,
-                31,
-                1
-              ]
-            },
-            {
-              "label": "Preset 3",
-              "type": "dropdown",
-              "options": [
-                [
-                  "100",
-                  10
-                ],
-                [
-                  "200",
-                  20
-                ],
-                [
-                  "300",
-                  30
-                ],
-                [
-                  "400",
-                  40
-                ],
-                [
-                  "500",
-                  50
-                ],
-                [
-                  "600",
-                  60
-                ],
-                [
-                  "700",
-                  70
-                ],
-                [
-                  "800",
-                  80
-                ],
-                [
-                  "900",
-                  90
-                ],
-                [
-                  "1000",
-                  100
-                ],
-                [
-                  "1200",
-                  120
-                ],
-                [
-                  "1400",
-                  140
-                ],
-                [
-                  "1600",
-                  160
-                ],
-                [
-                  "2000",
-                  200
-                ],
-                [
-                  "2400",
-                  240
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dpi_presets[2]",
-                0,
-                31,
-                2
-              ]
-            },
-            {
-              "label": "Preset 4",
-              "type": "dropdown",
-              "options": [
-                [
-                  "100",
-                  10
-                ],
-                [
-                  "200",
-                  20
-                ],
-                [
-                  "300",
-                  30
-                ],
-                [
-                  "400",
-                  40
-                ],
-                [
-                  "500",
-                  50
-                ],
-                [
-                  "600",
-                  60
-                ],
-                [
-                  "700",
-                  70
-                ],
-                [
-                  "800",
-                  80
-                ],
-                [
-                  "900",
-                  90
-                ],
-                [
-                  "1000",
-                  100
-                ],
-                [
-                  "1200",
-                  120
-                ],
-                [
-                  "1400",
-                  140
-                ],
-                [
-                  "1600",
-                  160
-                ],
-                [
-                  "2000",
-                  200
-                ],
-                [
-                  "2400",
-                  240
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dpi_presets[3]",
-                0,
-                31,
-                3
-              ]
-            },
-            {
-              "label": "Preset 5",
-              "type": "dropdown",
-              "options": [
-                [
-                  "100",
-                  10
-                ],
-                [
-                  "200",
-                  20
-                ],
-                [
-                  "300",
-                  30
-                ],
-                [
-                  "400",
-                  40
-                ],
-                [
-                  "500",
-                  50
-                ],
-                [
-                  "600",
-                  60
-                ],
-                [
-                  "700",
-                  70
-                ],
-                [
-                  "800",
-                  80
-                ],
-                [
-                  "900",
-                  90
-                ],
-                [
-                  "1000",
-                  100
-                ],
-                [
-                  "1200",
-                  120
-                ],
-                [
-                  "1400",
-                  140
-                ],
-                [
-                  "1600",
-                  160
-                ],
-                [
-                  "2000",
-                  200
-                ],
-                [
-                  "2400",
-                  240
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_dpi_presets[4]",
-                0,
-                31,
-                4
-              ]
-            }
-          ]
-        },
-        {
-          "label": "Sniper DPIs",
-          "content": [
-            {
-              "label": "Sniper DPI A",
-              "type": "dropdown",
-              "options": [
-                [
-                  "100",
-                  10
-                ],
-                [
-                  "150",
-                  15
-                ],
-                [
-                  "200",
-                  20
-                ],
-                [
-                  "250",
-                  25
-                ],
-                [
-                  "300",
-                  30
-                ],
-                [
-                  "350",
-                  35
-                ],
-                [
-                  "400",
-                  40
-                ],
-                [
-                  "450",
-                  45
-                ],
-                [
-                  "500",
-                  50
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_sniper_a_dpi",
-                0,
-                41
-              ]
-            },
-            {
-              "label": "Sniper DPI B",
-              "type": "dropdown",
-              "options": [
-                [
-                  "100",
-                  10
-                ],
-                [
-                  "150",
-                  15
-                ],
-                [
-                  "200",
-                  20
-                ],
-                [
-                  "250",
-                  25
-                ],
-                [
-                  "300",
-                  30
-                ],
-                [
-                  "350",
-                  35
-                ],
-                [
-                  "400",
-                  40
-                ],
-                [
-                  "450",
-                  45
-                ],
-                [
-                  "500",
-                  50
-                ]
-              ],
-              "content": [
-                "id_ploopystuff_sniper_b_dpi",
-                0,
-                42
-              ]
-            }
-          ]
-        }
-      ]
+    "layouts": {
+        "labels": [
+            [
+                "Show wheel as",
+                "Encoder",
+                "Button"
+            ]
+        ],
+        "keymap": [
+            [
+                {
+                    "h": 2
+                },
+                "0,0",
+                {
+                    "x": 1.5,
+                    "h": 2
+                },
+                "0,2",
+                {
+                    "x": 0.5,
+                    "h": 2
+                },
+                "0,3",
+                {
+                    "h": 2
+                },
+                "0,4"
+            ],
+            [
+                {
+                    "y": -0.75,
+                    "x": 1,
+                    "w": 1.5,
+                    "h": 1.5
+                },
+                "0,1\n\n\n0,0\n\n\n\n\n\ne0"
+            ],
+            [
+                {
+                    "y": 1,
+                    "x": 1,
+                    "w": 1.5,
+                    "h": 1.5,
+                    "d": true
+                },
+                "\n\n\n0,1",
+                {
+                    "x": -1.25,
+                    "h": 1.5
+                },
+                "0,1\n\n\n0,1"
+            ]
+        ]
     },
-    {
-      "label": "DragActions",
-      "content": [
+    "menus": [
         {
-          "label": "DragAction A",
-          "content": [
-            {
-              "label": "Up",
-              "type": "keycode",
-              "content": [
-                "id_ploopystuff_dragscroll_dragact_a_up",
-                0,
-                61
-              ]
-            },
-            {
-              "label": "Down",
-              "type": "keycode",
-              "content": [
-                "id_ploopystuff_dragscroll_dragact_a_down",
-                0,
-                62
-              ]
-            },
-            {
-              "label": "Left",
-              "type": "keycode",
-              "content": [
-                "id_ploopystuff_dragscroll_dragact_a_left",
-                0,
-                63
-              ]
-            },
-            {
-              "label": "Right",
-              "type": "keycode",
-              "content": [
-                "id_ploopystuff_dragscroll_dragact_a_right",
-                0,
-                64
-              ]
-            }
-          ]
+            "label": "Ploopy Stuff",
+            "content": [
+                {
+                    "label": "Settings",
+                    "content": [
+                        {
+                            "label": "Active DPI Preset",
+                            "type": "dropdown",
+                            "options": [
+                                ["1", 0],
+                                ["2", 1],
+                                ["3", 2],
+                                ["4", 3],
+                                ["5", 4]
+                            ],
+                            "content": ["id_ploopystuff_dpi_activepreset", 0, 1]
+                        },
+                        {
+                            "label": "DPI Multiplier",
+                            "type": "dropdown",
+                            "options": [
+                                ["0.25x", 5],
+                                ["0.5x", 10],
+                                ["0.75x", 15],
+                                ["1x", 20],
+                                ["1.25x", 25],
+                                ["1.5x", 30],
+                                ["1.75x", 35],
+                                ["2x", 40],
+                                ["2.5x", 50],
+                                ["3x", 60],
+                                ["4x", 80],
+                                ["5x", 100]
+                            ],
+                            "content": ["id_ploopystuff_dpi_multiplier", 0, 2]
+                        },
+                        {
+                            "label": "Mouse Jiggler",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_msjiggler_enabled", 0, 3]
+                        },
+                        {
+                            "label": "Pointer Invert X",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_pointer_invert_h", 0, 4]
+                        },
+                        {
+                            "label": "Pointer Invert Y",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_pointer_invert_v", 0, 5]
+                        }
+                    ]
+                },
+                {
+                    "label": "Gestures",
+                    "content": [
+                        {
+                            "label": "Wiggleball Wiggle Count",
+                            "type": "dropdown",
+                            "options": [
+                                ["2", 2],
+                                ["3", 3],
+                                ["4", 4],
+                                ["5", 5],
+                                ["6", 6],
+                                ["7", 7],
+                                ["8", 8],
+                                ["9", 9],
+                                ["10", 10]
+                            ],
+                            "content": ["id_ploopystuff_gesture_count", 0, 11]
+                        },
+                        {
+                            "label": "Wiggleball H",
+                            "type": "dropdown",
+                            "options": [
+                                ["Do Nothing", 0],
+                                ["Dragscroll", 1],
+                                ["Mouse Jiggler", 2]
+                            ],
+                            "content": ["id_ploopystuff_gesture_action_h", 0, 12]
+                        },
+                        {
+                            "label": "Wiggleball V",
+                            "type": "dropdown",
+                            "options": [
+                                ["Do Nothing", 0],
+                                ["Dragscroll", 1],
+                                ["Mouse Jiggler", 2]
+                            ],
+                            "content": ["id_ploopystuff_gesture_action_v", 0, 13]
+                        },
+                        {
+                            "label": "Combos Enable",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_combos_enabled", 0, 14]
+                        }
+                    ]
+                },
+                {
+                    "label": "Dragscroll",
+                    "content": [
+                        {
+                            "label": "Dragscroll Divisor X",
+                            "type": "dropdown",
+                            "options": [
+                                ["Off", 0],
+                                ["1", 4],
+                                ["1.5", 6],
+                                ["2", 8],
+                                ["2.5", 10],
+                                ["3", 12],
+                                ["3.5", 14],
+                                ["4", 16],
+                                ["4.5", 18],
+                                ["5", 20],
+                                ["6", 24],
+                                ["7", 28],
+                                ["8", 32],
+                                ["10", 40],
+                                ["12", 48],
+                                ["16", 64],
+                                ["20", 80],
+                                ["24", 96],
+                                ["32", 128],
+                                ["48", 192],
+                                ["64", 255]
+                            ],
+                            "content": ["id_ploopystuff_dragscroll_divisor_h", 0, 23]
+                        },
+                        {
+                            "label": "Dragscroll Divisor Y",
+                            "type": "dropdown",
+                            "options": [
+                                ["Off", 0],
+                                ["1", 4],
+                                ["1.5", 6],
+                                ["2", 8],
+                                ["2.5", 10],
+                                ["3", 12],
+                                ["3.5", 14],
+                                ["4", 16],
+                                ["4.5", 18],
+                                ["5", 20],
+                                ["6", 24],
+                                ["7", 28],
+                                ["8", 32],
+                                ["10", 40],
+                                ["12", 48],
+                                ["16", 64],
+                                ["20", 80],
+                                ["24", 96],
+                                ["32", 128],
+                                ["48", 192],
+                                ["64", 255]
+                            ],
+                            "content": ["id_ploopystuff_dragscroll_divisor_v", 0, 24]
+                        },
+                        {
+                            "label": "Dragscroll Invert X",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_invert_h", 0, 21]
+                        },
+                        {
+                            "label": "Dragscroll Invert Y",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_invert_v", 0, 22]
+                        },
+                        {
+                            "label": "Dragscroll Straighten",
+                            "type": "dropdown",
+                            "options": [
+                                ["Off",    0],
+                                ["25%",   25],
+                                ["50%",   50],
+                                ["75%",   75],
+                                ["85%",   85],
+                                ["90%",   90],
+                                ["95%",   95],
+                                ["100%", 100]
+                            ],
+                            "content": ["id_ploopystuff_dragscroll_straighten_enabled", 0, 51]
+                        }
+                    ]
+                },
+                {
+                    "label": "Moar Dragscroll",
+                    "content": [
+                        {
+                            "label": "Dragscroll on Caps Lock",
+                            "type": "dropdown",
+                            "options": [
+                                ["Off", 0],
+                                ["Scroll while enabled", 1],
+                                ["Scroll while disabled", 2]
+                            ],
+                            "content": ["id_ploopystuff_dragscroll_caps", 0, 25]
+                        },
+                        {
+                            "label": "Dragscroll on Num Lock",
+                            "type": "dropdown",
+                            "options": [
+                                ["Off", 0],
+                                ["Scroll while enabled", 1],
+                                ["Scroll while disabled", 2]
+                            ],
+                            "content": ["id_ploopystuff_dragscroll_num", 0, 26]
+                        },
+                        {
+                            "label": "Dragscroll on Scroll Lock",
+                            "type": "dropdown",
+                            "options": [
+                                ["Off", 0],
+                                ["Scroll while enabled", 1],
+                                ["Scroll while disabled", 2]
+                            ],
+                            "content": ["id_ploopystuff_dragscroll_scroll", 0, 27]
+                        },
+                        {
+                            "label": "Dragscroll on Permanently",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_permanently", 0, 29]
+                        },
+                        {
+                            "label": "Dragscroll end on keypress",
+                            "type": "toggle",
+                            "content": ["id_ploopystuff_dragscroll_end_on_keypress", 0, 28]
+                        }
+                    ]
+                },
+                {
+                    "label": "DPI Presets",
+                    "content": [
+                        {
+                            "label": "Preset 1",
+                            "type": "dropdown",
+                            "options": [
+                                ["100", 10],
+                                ["200", 20],
+                                ["300", 30],
+                                ["400", 40],
+                                ["500", 50],
+                                ["600", 60],
+                                ["700", 70],
+                                ["800", 80],
+                                ["900", 90],
+                                ["1000", 100],
+                                ["1200", 120],
+                                ["1400", 140],
+                                ["1600", 160],
+                                ["2000", 200],
+                                ["2400", 240]
+                            ],
+                            "content": ["id_ploopystuff_dpi_presets[0]", 0, 31, 0]
+                        },
+                        {
+                            "label": "Preset 2",
+                            "type": "dropdown",
+                            "options": [
+                                ["100", 10],
+                                ["200", 20],
+                                ["300", 30],
+                                ["400", 40],
+                                ["500", 50],
+                                ["600", 60],
+                                ["700", 70],
+                                ["800", 80],
+                                ["900", 90],
+                                ["1000", 100],
+                                ["1200", 120],
+                                ["1400", 140],
+                                ["1600", 160],
+                                ["2000", 200],
+                                ["2400", 240]
+                            ],
+                            "content": ["id_ploopystuff_dpi_presets[1]", 0, 31, 1]
+                        },
+                        {
+                            "label": "Preset 3",
+                            "type": "dropdown",
+                            "options": [
+                                ["100", 10],
+                                ["200", 20],
+                                ["300", 30],
+                                ["400", 40],
+                                ["500", 50],
+                                ["600", 60],
+                                ["700", 70],
+                                ["800", 80],
+                                ["900", 90],
+                                ["1000", 100],
+                                ["1200", 120],
+                                ["1400", 140],
+                                ["1600", 160],
+                                ["2000", 200],
+                                ["2400", 240]
+                            ],
+                            "content": ["id_ploopystuff_dpi_presets[2]", 0, 31, 2]
+                        },
+                        {
+                            "label": "Preset 4",
+                            "type": "dropdown",
+                            "options": [
+                                ["100", 10],
+                                ["200", 20],
+                                ["300", 30],
+                                ["400", 40],
+                                ["500", 50],
+                                ["600", 60],
+                                ["700", 70],
+                                ["800", 80],
+                                ["900", 90],
+                                ["1000", 100],
+                                ["1200", 120],
+                                ["1400", 140],
+                                ["1600", 160],
+                                ["2000", 200],
+                                ["2400", 240]
+                            ],
+                            "content": ["id_ploopystuff_dpi_presets[3]", 0, 31, 3]
+                        },
+                        {
+                            "label": "Preset 5",
+                            "type": "dropdown",
+                            "options": [
+                                ["100", 10],
+                                ["200", 20],
+                                ["300", 30],
+                                ["400", 40],
+                                ["500", 50],
+                                ["600", 60],
+                                ["700", 70],
+                                ["800", 80],
+                                ["900", 90],
+                                ["1000", 100],
+                                ["1200", 120],
+                                ["1400", 140],
+                                ["1600", 160],
+                                ["2000", 200],
+                                ["2400", 240]
+                            ],
+                            "content": ["id_ploopystuff_dpi_presets[4]", 0, 31, 4]
+                        }
+                    ]
+                },
+                {
+                    "label": "Sniper DPIs",
+                    "content": [
+                        {
+                            "label": "Sniper DPI A",
+                            "type": "dropdown",
+                            "options": [
+                                ["100", 10],
+                                ["150", 15],
+                                ["200", 20],
+                                ["250", 25],
+                                ["300", 30],
+                                ["350", 35],
+                                ["400", 40],
+                                ["450", 45],
+                                ["500", 50]
+                            ],
+                            "content": ["id_ploopystuff_sniper_a_dpi", 0, 41]
+                        },
+                        {
+                            "label": "Sniper DPI B",
+                            "type": "dropdown",
+                            "options": [
+                                ["100", 10],
+                                ["150", 15],
+                                ["200", 20],
+                                ["250", 25],
+                                ["300", 30],
+                                ["350", 35],
+                                ["400", 40],
+                                ["450", 45],
+                                ["500", 50]
+                            ],
+                            "content": ["id_ploopystuff_sniper_b_dpi", 0, 42]
+                        }
+                    ]
+                }
+            ]
         },
         {
-          "label": "DragAction B",
-          "content": [
-            {
-              "label": "Up",
-              "type": "keycode",
-              "content": [
-                "id_ploopystuff_dragscroll_dragact_b_up",
-                0,
-                65
-              ]
-            },
-            {
-              "label": "Down",
-              "type": "keycode",
-              "content": [
-                "id_ploopystuff_dragscroll_dragact_b_down",
-                0,
-                66
-              ]
-            },
-            {
-              "label": "Left",
-              "type": "keycode",
-              "content": [
-                "id_ploopystuff_dragscroll_dragact_b_left",
-                0,
-                67
-              ]
-            },
-            {
-              "label": "Right",
-              "type": "keycode",
-              "content": [
-                "id_ploopystuff_dragscroll_dragact_b_right",
-                0,
-                68
-              ]
-            }
-          ]
+            "label": "DragActions",
+            "content": [
+                {
+                    "label": "DragAction A",
+                    "content": [
+                        {
+                            "label": "Up",
+                            "type": "keycode",
+                            "content": ["id_ploopystuff_dragscroll_dragact_a_up", 0, 61]
+                        },
+                        {
+                            "label": "Down",
+                            "type": "keycode",
+                            "content": ["id_ploopystuff_dragscroll_dragact_a_down", 0, 62]
+                        },
+                        {
+                            "label": "Left",
+                            "type": "keycode",
+                            "content": ["id_ploopystuff_dragscroll_dragact_a_left", 0, 63]
+                        },
+                        {
+                            "label": "Right",
+                            "type": "keycode",
+                            "content": ["id_ploopystuff_dragscroll_dragact_a_right", 0, 64]
+                        }
+                    ]
+                },
+                {
+                    "label": "DragAction B",
+                    "content": [
+                        {
+                            "label": "Up",
+                            "type": "keycode",
+                            "content": ["id_ploopystuff_dragscroll_dragact_b_up", 0, 65]
+                        },
+                        {
+                            "label": "Down",
+                            "type": "keycode",
+                            "content": ["id_ploopystuff_dragscroll_dragact_b_down", 0, 66]
+                        },
+                        {
+                            "label": "Left",
+                            "type": "keycode",
+                            "content": ["id_ploopystuff_dragscroll_dragact_b_left", 0, 67]
+                        },
+                        {
+                            "label": "Right",
+                            "type": "keycode",
+                            "content": ["id_ploopystuff_dragscroll_dragact_b_right", 0, 68]
+                        }
+                    ]
+                }
+            ]
         }
-      ]
-    }
-  ]
-}
+    ]
+  }


### PR DESCRIPTION
Hello! I just got a Ploopy Classic 2 and stumbled upon your repo when looping for options to set DPI in usevia.app, great project btw. The one other thing I did want though was an autoclicker and was pretty bummed that QMK macros wouldn't work. I was about to import a module from another user when I noticed you had a turbo module in your modules repo and all I had to do was wire it in.

I am not great with C or QMK, but I did my best and can confirm it works. In this form it has some limitations though:
- Only one turbo fire key configured
- Key is hard mapped to left click
- Fire rate is hard set to 40ms (Linux key repeat interval)
- Only the trackball config was edited as I do not own the other devices and I'm not confident enough to assume it'd work, but I don't doubt it.

I don't know if you had any plans to implement this, I just thought I would share my work. I have no idea how to expose the turbo keys or interval in Via, so I will have to leave that to you.

Edit: It was not until after posting this that I saw the mention of turbo in the readme lol.